### PR TITLE
Add test folder for docs file

### DIFF
--- a/docs/directory.md
+++ b/docs/directory.md
@@ -1,0 +1,3 @@
+# Directory
+
+Test file for [default community health files](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file)


### PR DESCRIPTION
`/docs` seems to allegedly have special properties within this repository.  The idea is that any repository that does not have an overriding file with the same name automatically has access to these files.  Theoretically we could store the entire documentation for all of our infrastructure and terraform/workflow modules in the organization in this folder, and every repo gain access?  Need some prodding of this feature to find out if that tracks.