### PR TITLE
update checkov scan to output in cli instead of codeql

### DIFF
--- a/.github/workflows/tf-scan.yml
+++ b/.github/workflows/tf-scan.yml
@@ -19,13 +19,8 @@ jobs:
         uses: bridgecrewio/checkov-action@master
         with:
           directory: ${{ inputs.directory }}
+          quiet: true
           framework: terraform # optional: run only on a specific infrastructure {cloudformation,terraform,kubernetes,all}
-          output_format: sarif # optional: the output format, one of: cli, json, junitxml, github_failed_only, or sarif. Default: sarif
-          output_file_path: results/tfresults.sarif
-
-      - name: Upload SARIF file
-        if: always()
-        uses: github/codeql-action/upload-sarif@v2
-        with:
-          # Path to SARIF file relative to the root of the repository
-          sarif_file: results/tfresults.sarif
+          output_format: cli # optional: the output format, one of: cli, json, junitxml, github_failed_only, or sarif. Default: sarif
+          output_file_path: console
+          download_external_modules: true


### PR DESCRIPTION
We're changing checkov scanning to use cli output/annotations instead of codeQL uploads because we ended up not subscribing to github enterprise/advanced security.

- Set output to quiet (Only outputs failed tests)
- Set output format to cli and file path stdout
- Enabled download of external modules (so we'll have visibility into security problems with 3rd party modules and our own)