### PR TITLE
add scan-modules feature

### DIFF
--- a/.github/workflows/tf-scan.yml
+++ b/.github/workflows/tf-scan.yml
@@ -6,6 +6,10 @@ on:
         type: string
         description: "Directory to scan"
         default: "."
+      scan-modules:
+        type: boolean
+        description: "Scan external modules. This will cause soft fail to be enabled due to this issue: https://github.com/bridgecrewio/checkov/issues/4366"
+        default: false
 jobs:
   checkov-job:
     runs-on: ubuntu-latest
@@ -23,4 +27,5 @@ jobs:
           framework: terraform # optional: run only on a specific infrastructure {cloudformation,terraform,kubernetes,all}
           output_format: cli # optional: the output format, one of: cli, json, junitxml, github_failed_only, or sarif. Default: sarif
           output_file_path: console
-          download_external_modules: true
+          download_external_modules: ${{ inputs.scan-modules }}
+          soft_fail: ${{ !inputs.scan-modules }}


### PR DESCRIPTION
## Explanation
This was added to prevent 3rd party modules from causing failures across projects inadvertently.

Caused by a feature in checkov not being implemented yet, reference this issue for more details: https://github.com/bridgecrewio/checkov/issues/4366 

This means we don't have a good way of ensuring 3rd party modules (non-synapse modules) conform to our standards.

### Our practice moving forward should be that we do the following:
- Scrutinize all 3rd party modules for security
- Ensure our own modules conform to our security standards inside of their respective repositories
- Ensure this is communicated effectively to our Terraform maintainers e.g. the platform team
